### PR TITLE
Fix path to file to execute

### DIFF
--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -9,6 +9,6 @@ RUN mkdir /code/site
 WORKDIR /code/orderportal
 ENV PYTHONPATH /code
 
-CMD ["python3", "orderportal/app_orderportal.py"]
+CMD ["python3", "app_orderportal.py"]
 
 VOLUME ["/code/site"]


### PR DESCRIPTION
Since `WORKDIR` is set to `/code/orderportal` and `CMD` was `["python3", "orderportal/app_orderportal.py"]`, the container tries to execute the file at `/code/orderportal/orderportal/app_orderportal.py`, which does not exist.

The patch removes the extra `orderportal` in `CMD`.