### PR TITLE
Fix github actions container build

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -9,9 +9,16 @@ jobs:
     if: github.repository == 'pekrau/orderportal'
     name: Publish Docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to Github Container Repository
         uses: docker/login-action@v2
         with:
@@ -30,10 +37,11 @@ jobs:
              type=semver,pattern={{major}}.{{minor}}
              type=semver,pattern={{major}}
       - name: Build and publish backend
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           file: docker/Dockerfile-prod
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64


### PR DESCRIPTION
Restrict the permissions given to the workflow.

Add functionality for building on different CPU architectures. 
To add more CPU architectures adjust the __platform__ attribute, for example

```
platforms: linux/amd64,linux/arm64
```


I've only tested the PR in a private GitHub repository. In the test I replaced

```
on:
  release:
    types: [published]
```
with

```
on:
  push:
    branches:
      - 'master'
```
and 
```
    push: true
```
with
```
    push: false
```


I verified that the container was built.




